### PR TITLE
fix(Dockerfile): standardize file paths for eXist-db copying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN --mount=type=cache,id=maven,target=/root/.m2 \
 FROM gcr.io/distroless/java21-debian13:${DISTRO_TAG} AS build_full
 ARG USR=root
 # Copy autodeploy folder from dist
-ONBUILD COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-dir/autodeploy /exist/autodeploy
+ONBUILD COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/autodeploy /exist/autodeploy
 
 
 FROM gcr.io/distroless/java21-debian13:${DISTRO_TAG} AS build_slim
@@ -67,9 +67,9 @@ ONBUILD COPY --from=builder --chown=${USR} /no-auto /exist/autodeploy
 FROM build_${FLAVOR}
 ARG USR=root
 # Copy eXist-db
-COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-dir/LICENSE /exist/LICENSE
-COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-dir/etc /exist/etc
-COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-dir/lib /exist/lib
+COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/LICENSE /exist/LICENSE
+COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/etc /exist/etc
+COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/lib /exist/lib
 COPY --chown=${USR} log4j2.xml /exist/etc
 
 

--- a/Dockerfile_j11
+++ b/Dockerfile_j11
@@ -62,7 +62,7 @@ RUN --mount=type=cache,id=maven,target=/root/.m2 \
 FROM gcr.io/distroless/java-base-debian13:${DISTRO_TAG} AS build_full
 ARG USR=root
 # Copy autodeploy folder from dist
-ONBUILD COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-*-dir/autodeploy /exist/autodeploy
+ONBUILD COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/autodeploy /exist/autodeploy
 
 
 FROM gcr.io/distroless/java-base-debian13:${DISTRO_TAG} AS build_slim
@@ -77,9 +77,9 @@ COPY --from=eclipse-temurin:11-jre --chown=${USR} $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Copy eXist-db
-COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-*-dir/LICENSE /exist/LICENSE
-COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-*-dir/etc /exist/etc
-COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-*-dir/lib /exist/lib
+COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/LICENSE /exist/LICENSE
+COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/etc /exist/etc
+COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/lib /exist/lib
 COPY --chown=${USR} log4j2.xml /exist/etc
 
 

--- a/Dockerfile_j8
+++ b/Dockerfile_j8
@@ -62,7 +62,7 @@ RUN --mount=type=cache,id=maven,target=/root/.m2 \
 FROM gcr.io/distroless/java-base-debian13:${DISTRO_TAG} AS build_full
 ARG USR=root
 # Copy autodeploy folder from dist
-ONBUILD COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-*-dir/autodeploy /exist/autodeploy
+ONBUILD COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/autodeploy /exist/autodeploy
 
 
 FROM gcr.io/distroless/java-base-debian13:${DISTRO_TAG} AS build_slim
@@ -77,9 +77,9 @@ COPY --from=eclipse-temurin:8-jre --chown=${USR} $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Copy eXist-db
-COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-*-dir/LICENSE /exist/LICENSE
-COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-*-dir/etc /exist/etc
-COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution-*-dir/lib /exist/lib
+COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/LICENSE /exist/LICENSE
+COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/etc /exist/etc
+COPY --from=builder --chown=${USR} /exist/exist-distribution/target/exist-distribution*-dir/lib /exist/lib
 COPY --chown=${USR} log4j2.xml /exist/etc
 
 EXPOSE 8080 8443


### PR DESCRIPTION
Updated the Dockerfile to replace 'exist-distribution-*dir' with 'exist-distribution-dir' within Java8 and Java11 Dockerfiles for exist v6

see eXist-db/exist#6136